### PR TITLE
Add management interface using async networking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+tokio = { version = "1.28.0", default-features = false, features = ["io-util", "net", "rt", "macros", "fs", "sync", "time"] }
 
 [build-dependencies]
 bindgen = "0.65.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,22 +189,15 @@ pub static exports: bindings::module_exports = bindings::module_exports {
 };
 
 static DEPS: bindings::dep_export_concrete<1> = bindings::dep_export_concrete {
-    md: [
-        bindings::module_dependency {
+    md: {
+        let mut md = [bindings::module_dependency::NULL; 10];
+        md[0] = bindings::module_dependency {
             mod_type: bindings::module_type::MOD_TYPE_DEFAULT,
             mod_name: cstr_lit!(mut "signaling"),
             type_: bindings::DEP_ABORT,
-        },
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-        bindings::module_dependency::NULL,
-    ],
+        };
+        md
+    },
     mpd: [bindings::modparam_dependency::NULL],
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,11 @@ mod bindings {
         load_sig(sigb)
     }
 
+    #[inline]
+    pub fn init_mi_result_ok() -> *mut mi_response_t {
+        unsafe { init_mi_result_string("OK".as_ptr(), 2) }
+    }
+
     impl str_ {
         pub fn try_as_str(&self) -> Result<&str, core::str::Utf8Error> {
             let len = self.len.try_into().expect("TODO: report error");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,25 @@ mod bindings {
         };
     }
 
+    unsafe impl Sync for mi_export_t {}
+
+    impl mi_export_t {
+        pub const NULL: Self = Self {
+            name: ptr::null_mut(),
+            help: ptr::null_mut(),
+            flags: 0,
+            init_f: None,
+            recipes: [mi_recipe_t::NULL; 48],
+        };
+    }
+
+    impl mi_recipe_t {
+        pub const NULL: Self = Self {
+            cmd: None,
+            params: [ptr::null_mut(); 10],
+        };
+    }
+
     // The `dep_export_t` structure uses a Flexible Array Member
     // (FAM). These are quite annoying to deal with. Here, I create a
     // parallel structure that uses a const generic array. This


### PR DESCRIPTION
Traditional opensips modules use Linux shared memory to communicate
between different processes. Shared memory is not something I've dealt
with before, and it's not the most common thing to use in Rust.

Instead, I took the opportunity to demonstrate using spinning up a new
thread and running asynchronous networking code via Tokio. The parent
process creates a UNIX domain socket and awaits connections. Each
worker connects back to the parent.

When the management interface is triggered, that worker sends a packet
to the parent process, which then broadcasts the packet back out to
all of the children. When the children receive the packet, they
increment a counter.

To see this, you can perform an `OPTIONS` request, trigger the
management interface, then perform the `OPTIONS` request again. Note
that the counter value returned in the `OK` response changes:

```
$ sipsak -vv -s sip:127.0.0.1

   SIP/2.0 200 OK (hello world / 42 / 0)

$ docker exec -it opensips opensips-cli -x mi rust_experiment_control

"OK"

$ sipsak -vv -s sip:127.0.0.1

   SIP/2.0 200 OK (hello world / 42 / 1)
```