### PR TITLE
Demonstrate making an HTTP call and deserializing JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+reqwest = { version = "0.11.17", default-features = false, features = ["default-tls", "json"] }
 serde = { version = "1.0.163", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1.0.96", default-features = false, features = ["std"] }
 tokio = { version = "1.28.0", default-features = false, features = ["io-util", "net", "rt", "macros", "fs", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+serde = { version = "1.0.163", default-features = false, features = ["derive", "std"] }
+serde_json = { version = "1.0.96", default-features = false, features = ["std"] }
 tokio = { version = "1.28.0", default-features = false, features = ["io-util", "net", "rt", "macros", "fs", "sync", "time"] }
 
 [build-dependencies]


### PR DESCRIPTION
We now periodically access the https://random.dog API to retrieve the
URL of an image. That URL is broadcast to all the worker processes and
is returned as part of the `OPTIONS` response:

```
$ sipsak -vv -s sip:127.0.0.1

message received:
SIP/2.0 200 OK (hello world / 42 / 0 / https://random.dog/d7ae7fc7-e254-45da-8ac4-6afb898b6cc2.png)
```