### PR TITLE
Add ChatGPT integration via request/response headers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -61,9 +61,18 @@ impl ParseCallbacks for AdjustMacroTypes {
             "CMD_PARAM_STATIC",
         ];
 
-        if cmd_flag_macro_names.contains(&name) {
-            Some(IntKind::Int)
-        } else if cmd_param_macro_names.contains(&name) {
+        let lump_rpl_macro_names = [
+            "LUMP_RPL_HDR",
+            "LUMP_RPL_BODY",
+            "LUMP_RPL_NODUP",
+            "LUMP_RPL_NOFREE",
+            "LUMP_RPL_SHMEM",
+        ];
+
+        if cmd_flag_macro_names.contains(&name)
+            || cmd_param_macro_names.contains(&name)
+            || lump_rpl_macro_names.contains(&name)
+        {
             Some(IntKind::Int)
         } else {
             None

--- a/opensips_bindings.h
+++ b/opensips_bindings.h
@@ -43,3 +43,4 @@
 
 #include "sr_module.h"
 #include "modules/signaling/signaling.h"
+#include "data_lump_rpl.h"

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -1,0 +1,113 @@
+use reqwest::{
+    header::{self, HeaderMap, HeaderValue},
+    Client,
+};
+
+#[derive(Debug, serde::Serialize)]
+struct Request {
+    model: Model,
+    messages: Vec<Message>,
+}
+
+#[derive(Debug, serde::Serialize)]
+enum Model {
+    #[serde(rename = "gpt-3.5-turbo")]
+    Gpt35Turbo,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct Message {
+    role: Role,
+    content: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Role {
+    System,
+    User,
+    Assistant,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum Response {
+    Error { error: Error },
+    Success(SuccessResponse),
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Error {
+    message: String,
+    // type: String // "insufficient_quota" -- enum?
+    // param: null,
+    // code: null
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct SuccessResponse {
+    // id: String,
+    // object: String, // "chat.completion" -- enum?
+    // created: u64, // 1677652288,
+    choices: Vec<Choice>,
+    // usage: Usage,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Choice {
+    // index: u64,
+    message: Message,
+    // finish_reason: String // "stop" -- enum?
+}
+
+// struct Usage {
+//     prompt_tokens: u64,
+//     completion_tokens: u64,
+//     total_tokens: u64,
+// }
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn do_one(api_key: &str, message: &str) -> String {
+    let mut headers = HeaderMap::new();
+    let value = HeaderValue::from_maybe_shared(format!("Bearer {api_key}")).unwrap();
+    headers.append(header::AUTHORIZATION, value);
+
+    let client = Client::builder()
+        .default_headers(headers)
+        .build()
+        .expect("Could not create reqwest Client");
+
+    let request = Request {
+        model: Model::Gpt35Turbo,
+        messages: vec![
+            Message {
+                role: Role::System,
+                content: "You are OpenSIPS, an Open Source SIP proxy/server for voice, video, IM, presence and any other SIP extensions. Limit all responses to a single sentence.".into()
+            },
+
+            Message {
+                role: Role::User,
+                content: message.into(),
+            }
+        ],
+    };
+
+    let response = client
+        .post("https://api.openai.com/v1/chat/completions")
+        .json(&request)
+        .send()
+        .await
+        .expect("Could not make ChatGPT request")
+        .json::<Response>()
+        .await
+        .expect("Could not parse ChatGPT response");
+
+    match response {
+        Response::Error { error } => error.message,
+
+        Response::Success(mut success) => {
+            let Some(choice) = success.choices.pop() else { return "I have nothing to say for that".into() };
+            choice.message.content
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,8 @@ async fn run_server_loop() {
         std::process::id()
     );
 
+    // We don't care if deleting fails as binding will tell us.
+    let _ = fs::remove_file(CONTROL_SOCKET).await;
     let listener = UnixListener::bind(CONTROL_SOCKET).unwrap();
     // TODO: Find minimal appropriate permissions
     fs::set_permissions(CONTROL_SOCKET, Permissions::from_mode(0o777))


### PR DESCRIPTION
By passing the `X-ChatGPT` header in a request, you can see what
ChatGPT thinks in the response `X-ChatGPT` header:

```
$ sipsak -vv -s sip:127.0.0.1 -j 'X-ChatGPT: What language is OpenSIPS written in?' -Z 5000

[...snip...]

X-ChatGPT: OpenSIPS is written in C programming language.
```